### PR TITLE
fix path to javaNetSim.jar in windows.bat

### DIFF
--- a/windows.bat
+++ b/windows.bat
@@ -1,3 +1,3 @@
 rem Java > 1.5
-java -Xss50m -Xoss100m -jar javaNetSim.jar
+java -Xss50m -Xoss100m -jar bin/javaNetSim.jar
 rem -Xms100m -Xmx400m -Xss50m -Xoss100m


### PR DESCRIPTION
Hi! I needed to run this software for an exam at university, but encountered an error while running it on Windows. My commit fixes the issue